### PR TITLE
Fix moving to the first slide after ODP export

### DIFF
--- a/PortfolioActivity.py
+++ b/PortfolioActivity.py
@@ -1788,7 +1788,8 @@ class PortfolioActivity(activity.Activity):
             datastore.write(dsobject)
             dsobject.destroy()
             os.remove('/tmp/Portfolio.odp')
-            self.i = start_slide
+            self.i = 0
+            self._show_slide()
 
     def _get_image_list(self):
         image_list = []


### PR DESCRIPTION
Since "start_slide" does not exists, and there is nothing similar
to that, I assume that the intention was to move the slides position
to the first one, which in this case, would be "0" because is the
parametter passed to "_next_image" in the its first call.

Signed-off-by: Martin Abente Lahaye <tch@sugarlabs.org>